### PR TITLE
add build.gradle and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+/build

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'java'
+
+dependencies {
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+}


### PR DESCRIPTION
Adds the build.gradle for Gradle to build Android/Java project.
Adds .gitignore includes /build and .gradle/ so they are not tracked by Git.
