### PR TITLE
Add local build information so maven can build locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,9 @@
 apply plugin: 'java'
+apply plugin: 'maven'
+
+group = 'com.yelp.clientlib'
+archivesBaseName = "yelp-android"
+version = '1.0-SNAPSHOT'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
While we are working on pushing artifacts to Maven Central repository, we should let user be able to build the library locally and be imported by other project. 

By adding maven plugin, "gradle install" will create the pom files and install the artifacts to local .m2 repository.
