### PR TITLE
Add configurations into UploadArchives so it can deploy the artifacts to Sonatype OSSRH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .gradle/
 /build
-gradle.properties

--- a/build.gradle
+++ b/build.gradle
@@ -2,15 +2,16 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-group = 'com.yelp.clientlib'
-archivesBaseName = "yelp-android"
-version = '1.0-SNAPSHOT'
-
 repositories {
     mavenCentral()
 }
 
-// Set up integrationTest task to execute tests in src/integration-test separately from main build.
+/**
+ * Configure integration tests. Set up a new integrationTest task to execute tests in src/integration-test separately
+ * from the main build.
+ *
+ * To run all of the integration tests, run "gradle integrationTest".
+ */
 sourceSets {
     integrationTest {
         java {
@@ -38,6 +39,18 @@ task integrationTest(type: Test) {
 // Makes integration tests not run by default.
 check.dependsOn -= integrationTest
 
+/**
+ * Configure deployment.
+ *
+ * To deploy artifacts to public repository, run "gradle upload". You need to have "ossrhUsername", "ossrhPassword",
+ * "signing.keyId", "signing.password" and "signing.secretKeyRingFile" in your HOME/.gradle/gradle.properties file
+ * to upload archives.
+ *
+ * To deploy artifacts to local Maven repository, run "gradle install".
+ */
+group = 'com.yelp.clientlib'
+archivesBaseName = 'yelp-android'
+
 task javadocJar(type: Jar) {
     classifier = 'javadoc'
     from javadoc
@@ -52,27 +65,38 @@ artifacts {
     archives javadocJar, sourcesJar
 }
 
-signing {
-    sign configurations.archives
+task checkOSSRHProperties << {
+    if (project.properties['ossrhUsername'] == null || project.properties['ossrhPassword'] == null) {
+        throw new IllegalStateException('ERROR: you need to have ossrhUsername and ossrhPassword properties' +
+                ' defined in your HOME/.gradle/gradle.properties file to upload archives');
+    }
+    if (project.properties['signing.keyId'] == null || project.properties['signing.password'] == null || project
+            .properties['signing.secretKeyRingFile'] == null) {
+        throw new IllegalStateException('ERROR: you need to have signing.keyId, signing.password and ' +
+                'signing.secretKeyRingFile properties defined in your HOME/.gradle/gradle.properties file to sign ' +
+                'the archives.');
+    }
 }
 
 uploadArchives {
+    dependsOn checkOSSRHProperties
     repositories {
         mavenDeployer {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+            repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
+                authentication(userName: project.properties['ossrhUsername'], password: project.properties['ossrhPassword'])
             }
 
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+            snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots') {
+                authentication(userName: project.properties['ossrhUsername'], password: project.properties['ossrhPassword'])
             }
 
             pom.project {
                 name 'Yelp Android Clientlib'
                 packaging 'jar'
-                description 'A Java library for the Yelp API. It simplifies the process of authentication, request construction, and response parsing for Java/Android developers using the Yelp API.'
+                description 'A Java library for the Yelp API. It simplifies the process of authentication, request ' +
+                        'construction, and response parsing for Java/Android developers using the Yelp API.'
                 url 'https://www.yelp.com/developers'
 
                 scm {
@@ -92,6 +116,14 @@ uploadArchives {
     }
 }
 
+signing {
+    required { gradle.taskGraph.hasTask('uploadArchives') }
+    sign configurations.archives
+}
+
+/**
+ * Configure package dependencies.
+ */
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.google.auto.value:auto-value:1.1'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+version=1.0.0-SNAPSHOT

--- a/src/main/java/com/yelp/clientlib/entities/options/CoordinateOptions.java
+++ b/src/main/java/com/yelp/clientlib/entities/options/CoordinateOptions.java
@@ -35,11 +35,11 @@ public abstract class CoordinateOptions {
     public abstract Double altitudeAccuracy();
 
     /**
-     * String presentation for {@link CoordinateOptions}. The generated string is comma separated. It is encoded in the
-     * order of latitude, longitude, accuracy, altitude and altitudeAccuracy. This method is used by {@link retrofit
+     * String presentation for {@code CoordinateOptions}. The generated string is comma separated. It is encoded in the
+     * order of latitude, longitude, accuracy, altitude and altitudeAccuracy. This method is used by {@code retrofit
      * .http.QueryMap} to generate the values of query parameters.
      *
-     * @return String presentation for {@link CoordinateOptions}
+     * @return String presentation for {@code CoordinateOptions}
      */
     @Override
     public String toString() {
@@ -92,9 +92,9 @@ public abstract class CoordinateOptions {
         public abstract Builder altitudeAccuracy(Double altitudeAccuracy);
 
         /**
-         * Returns a reference to the object of {@link CoordinateOptions} being constructed by the builder.
+         * Returns a reference to the object of {@code CoordinateOptions} being constructed by the builder.
          *
-         * @return the {@link CoordinateOptions} constructed by the builder.
+         * @return the {@code CoordinateOptions} constructed by the builder.
          */
         public abstract CoordinateOptions build();
     }


### PR DESCRIPTION
As our Sonatype project is already set up and ready, this branch adds the configurations into the UploadArchives task in gradle Java plugin. After this change, we can do a easy `gradle upload` to upload the artifacts into the Sonatype OSSRH. And then from there, we manually promote releases to Maven Central.

The project coordinates will be groupId:`com.yelp.clientlib` and the artifactId: `yelp-android`.

version is set in `REPO/gradle.properties` so it's easier to be updated in the future. Now it's set to `1.0.0-SNAPSHOT`.

To protect the signing key and secret, related information are going to be stored in `HOME/.gradle/gradle.properties` locally instead of any part of this repo. These signing related information is only required when `gradle upload` is called to upload the artifacts into Sonatype. 

The javadoc in CoordinateOptions.java is fixed so the javadoc can be generated without warning.

Some references for uploading files to Sonatype:
https://maven.apache.org/guides/mini/guide-central-repository-upload.html
http://central.sonatype.org/pages/gradle.html
http://central.sonatype.org/pages/choosing-your-coordinates.html
http://central.sonatype.org/pages/ossrh-guide.html
