### PR TITLE
add developer information into build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,11 @@ uploadArchives {
 
                 developers {
                     developer {
+                        name 'Yelp'
+                        email 'api+android@yelp.com'
+                    }
+
+                    developer {
                         id 'tzuhanwu'
                         name 'Tzu-Han Wu'
                         email 'tzuhanwu@yelp.com'


### PR DESCRIPTION
Maven central requires us to put developer information into the build-script, it blocks us to publish the artifacts into public repository without the developers fields are filled.

Reference: http://central.sonatype.org/pages/requirements.html#developer-information
