### PR TITLE
Upgrade retrofit to 2 0 0 stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ You can also pass in a `Callback` object to send the request asynchronously. For
 ```java
 Callback<SearchResponse> callback = new Callback<SearchResponse>() {
     @Override
-    public void onResponse(Response<SearchResponse> response, Retrofit retrofit) {
+    public void onResponse(Call<SearchResponse> call, Response<SearchResponse> response) {
         SearchResponse searchResponse = response.body();
         // Update UI text with the searchResponse.
     }
     @Override
-    public void onFailure(Throwable t) {
+    public void onFailure(Call<SearchResponse> call, Throwable t) {
         // HTTP error happened, do something to handle it.
     }
 };
@@ -137,12 +137,12 @@ use `Call.enqueue()` to set `Callback` function for an asynchronous request.
 ```java
 Callback<Business> callback = new Callback<Business>() {
     @Override
-    public void onResponse(Response<Business> response, Retrofit retrofit) {
+    public void onResponse(Call<Business> call, Response<Business> response) {
         Business business = response.body();
         // Update UI text with the Business object.
     }
     @Override
-    public void onFailure(Throwable t) {
+    public void onFailure(Call<Business> call, Throwable t) {
         // HTTP error happened, do something to handle it.
     }
 };

--- a/build.gradle
+++ b/build.gradle
@@ -140,11 +140,11 @@ signing {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.google.auto.value:auto-value:1.1'
-    compile 'com.squareup.retrofit:retrofit:2.0.0-beta2'
-    compile 'com.squareup.retrofit:converter-jackson:2.0.0-beta2'
+    compile 'com.squareup.retrofit2:retrofit:2.0.0'
+    compile 'com.squareup.retrofit2:converter-jackson:2.0.0'
     compile 'oauth.signpost:signpost-core:1.2.1.2'
     compile 'se.akerfeldt:okhttp-signpost:1.0.0'
-    compile 'com.squareup.okhttp:okhttp:2.7.0'
+    compile 'com.squareup.okhttp3:okhttp:3.1.2'
 
     testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.6.3'
     testCompile 'com.squareup.okhttp:mockwebserver:2.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -143,11 +143,11 @@ dependencies {
     compile 'com.squareup.retrofit2:retrofit:2.0.0'
     compile 'com.squareup.retrofit2:converter-jackson:2.0.0'
     compile 'oauth.signpost:signpost-core:1.2.1.2'
-    compile 'se.akerfeldt:okhttp-signpost:1.0.0'
+    compile 'se.akerfeldt:okhttp-signpost:1.1.0'
     compile 'com.squareup.okhttp3:okhttp:3.1.2'
 
     testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.6.3'
-    testCompile 'com.squareup.okhttp:mockwebserver:2.7.0'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.2.0'
     testCompile 'org.easymock:easymock:3.4'
     testCompile 'org.powermock:powermock-api-easymock:1.6.4'
     testCompile 'org.powermock:powermock-module-junit4:1.6.4'

--- a/src/integration-test/java/com/yelp/clientlib/BusinessIntegrationTest.java
+++ b/src/integration-test/java/com/yelp/clientlib/BusinessIntegrationTest.java
@@ -77,12 +77,12 @@ public class BusinessIntegrationTest {
         final ArrayList<Response<Business>> responseWrapper = new ArrayList<>();
         Callback<Business> businessCallback = new Callback<Business>() {
             @Override
-            public void onResponse(Response<Business> response, Retrofit retrofit) {
+            public void onResponse(Call<Business> call, Response<Business> response) {
                 responseWrapper.add(response);
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Call<Business> call, Throwable t) {
                 Assert.fail("Unexpected failure: " + t.toString());
             }
         };
@@ -120,12 +120,12 @@ public class BusinessIntegrationTest {
     public void testGetBusinessAsynchronousWith400Response() throws IOException {
         Callback<Business> businessCallback = new Callback<Business>() {
             @Override
-            public void onResponse(Response<Business> response, Retrofit retrofit) {
+            public void onResponse(Call<Business> call, Response<Business> response) {
                 Assert.fail("Expected failure not returned.");
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Call<Business> call, Throwable t) {
                 Assert.assertTrue(t instanceof BusinessUnavailable);
                 ErrorTestUtils.verifyErrorContent(
                         (YelpAPIError) t,

--- a/src/integration-test/java/com/yelp/clientlib/BusinessIntegrationTest.java
+++ b/src/integration-test/java/com/yelp/clientlib/BusinessIntegrationTest.java
@@ -17,10 +17,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import retrofit.Call;
-import retrofit.Callback;
-import retrofit.Response;
-import retrofit.Retrofit;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import retrofit2.Retrofit;
 
 /**
  * TODO: Move this class to other directory so src/java/test only contains unit-tests related files.

--- a/src/integration-test/java/com/yelp/clientlib/PhoneSearchIntegrationTest.java
+++ b/src/integration-test/java/com/yelp/clientlib/PhoneSearchIntegrationTest.java
@@ -15,10 +15,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import retrofit.Call;
-import retrofit.Callback;
-import retrofit.Response;
-import retrofit.Retrofit;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import retrofit2.Retrofit;
 
 /**
  * TODO: Move this class to other directory so src/java/test only contains unit-tests related files.

--- a/src/integration-test/java/com/yelp/clientlib/PhoneSearchIntegrationTest.java
+++ b/src/integration-test/java/com/yelp/clientlib/PhoneSearchIntegrationTest.java
@@ -75,12 +75,12 @@ public class PhoneSearchIntegrationTest {
         final ArrayList<Response<SearchResponse>> responseWrapper = new ArrayList<>();
         Callback<SearchResponse> searchCallback = new Callback<SearchResponse>() {
             @Override
-            public void onResponse(Response<SearchResponse> response, Retrofit retrofit) {
+            public void onResponse(Call<SearchResponse> call, Response<SearchResponse> response) {
                 responseWrapper.add(response);
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Call<SearchResponse> call, Throwable t) {
                 Assert.fail("Unexpected failure: " + t.toString());
             }
         };

--- a/src/integration-test/java/com/yelp/clientlib/SearchIntegrationTest.java
+++ b/src/integration-test/java/com/yelp/clientlib/SearchIntegrationTest.java
@@ -15,8 +15,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import retrofit.Call;
-import retrofit.Response;
+import retrofit2.Call;
+import retrofit2.Response;
 
 /**
  * TODO: Move this class to other directory so src/java/test only contains unit-tests related files.

--- a/src/main/java/com/yelp/clientlib/connection/YelpAPI.java
+++ b/src/main/java/com/yelp/clientlib/connection/YelpAPI.java
@@ -7,11 +7,11 @@ import com.yelp.clientlib.entities.options.CoordinateOptions;
 
 import java.util.Map;
 
-import retrofit.Call;
-import retrofit.http.GET;
-import retrofit.http.Path;
-import retrofit.http.Query;
-import retrofit.http.QueryMap;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+import retrofit2.http.QueryMap;
 
 public interface YelpAPI {
 

--- a/src/main/java/com/yelp/clientlib/connection/YelpAPIFactory.java
+++ b/src/main/java/com/yelp/clientlib/connection/YelpAPIFactory.java
@@ -1,10 +1,10 @@
 package com.yelp.clientlib.connection;
 
-import com.squareup.okhttp.OkHttpClient;
+import okhttp3.OkHttpClient;
 import com.yelp.clientlib.exception.ErrorHandlingInterceptor;
 
-import retrofit.JacksonConverterFactory;
-import retrofit.Retrofit;
+import retrofit2.JacksonConverterFactory;
+import retrofit2.Retrofit;
 import se.akerfeldt.okhttp.signpost.OkHttpOAuthConsumer;
 import se.akerfeldt.okhttp.signpost.SigningInterceptor;
 

--- a/src/main/java/com/yelp/clientlib/connection/YelpAPIFactory.java
+++ b/src/main/java/com/yelp/clientlib/connection/YelpAPIFactory.java
@@ -3,7 +3,7 @@ package com.yelp.clientlib.connection;
 import okhttp3.OkHttpClient;
 import com.yelp.clientlib.exception.ErrorHandlingInterceptor;
 
-import retrofit2.JacksonConverterFactory;
+import retrofit2.converter.jackson.JacksonConverterFactory;
 import retrofit2.Retrofit;
 import se.akerfeldt.okhttp.signpost.OkHttpOAuthConsumer;
 import se.akerfeldt.okhttp.signpost.SigningInterceptor;
@@ -36,9 +36,11 @@ public class YelpAPIFactory {
     public YelpAPIFactory(String consumerKey, String consumerSecret, String token, String tokenSecret) {
         OkHttpOAuthConsumer consumer = new OkHttpOAuthConsumer(consumerKey, consumerSecret);
         consumer.setTokenWithSecret(token, tokenSecret);
-        this.httpClient = new OkHttpClient();
-        this.httpClient.interceptors().add(new SigningInterceptor(consumer));
-        this.httpClient.interceptors().add(new ErrorHandlingInterceptor());
+
+        this.httpClient = new OkHttpClient.Builder()
+                .addInterceptor(new SigningInterceptor(consumer))
+                .addInterceptor(new ErrorHandlingInterceptor())
+                .build();
     }
 
     /**

--- a/src/main/java/com/yelp/clientlib/entities/options/BoundingBoxOptions.java
+++ b/src/main/java/com/yelp/clientlib/entities/options/BoundingBoxOptions.java
@@ -27,7 +27,7 @@ public abstract class BoundingBoxOptions {
 
     /**
      * String presentation for {@link BoundingBoxOptions}. The generated string is encoded as
-     * "swLatitude,swLongitude%7CneLatitude,neLongitude". This method is used by {@link retrofit.http.Query} to
+     * "swLatitude,swLongitude%7CneLatitude,neLongitude". This method is used by {@link retrofit2.http.Query} to
      * generate the values of query parameters.
      *
      * BoundingBox query param value contains non-suggested URI character '|' which doesn't fit into most of the

--- a/src/main/java/com/yelp/clientlib/exception/ErrorHandlingInterceptor.java
+++ b/src/main/java/com/yelp/clientlib/exception/ErrorHandlingInterceptor.java
@@ -2,8 +2,8 @@ package com.yelp.clientlib.exception;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.squareup.okhttp.Interceptor;
-import com.squareup.okhttp.Response;
+import okhttp3.Interceptor;
+import okhttp3.Response;
 import com.yelp.clientlib.exception.exceptions.AreaTooLarge;
 import com.yelp.clientlib.exception.exceptions.BadCategory;
 import com.yelp.clientlib.exception.exceptions.BusinessUnavailable;

--- a/src/main/java/com/yelp/clientlib/exception/ErrorHandlingInterceptor.java
+++ b/src/main/java/com/yelp/clientlib/exception/ErrorHandlingInterceptor.java
@@ -33,7 +33,7 @@ public class ErrorHandlingInterceptor implements Interceptor {
     /**
      * Intercept HTTP responses and raise a {@link YelpAPIError} if the response code is not 2xx.
      *
-     * @param chain {@link com.squareup.okhttp.Interceptor.Chain} object for sending the HTTP request.
+     * @param chain {@link okhttp3.Interceptor.Chain} object for sending the HTTP request.
      * @return response
      * @throws IOException {@link YelpAPIError} generated depends on the response error id.
      */

--- a/src/test/java/com/yelp/clientlib/connection/YelpAPITest.java
+++ b/src/test/java/com/yelp/clientlib/connection/YelpAPITest.java
@@ -1,9 +1,9 @@
 package com.yelp.clientlib.connection;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import com.yelp.clientlib.entities.Business;
 import com.yelp.clientlib.utils.JsonTestUtils;
 import com.yelp.clientlib.entities.SearchResponse;
@@ -23,10 +23,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import retrofit.Call;
-import retrofit.Callback;
-import retrofit.Response;
-import retrofit.Retrofit;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import retrofit2.Retrofit;
 
 public class YelpAPITest {
     private MockWebServer mockServer;

--- a/src/test/java/com/yelp/clientlib/connection/YelpAPITest.java
+++ b/src/test/java/com/yelp/clientlib/connection/YelpAPITest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
-import retrofit2.Retrofit;
 
 public class YelpAPITest {
     private MockWebServer mockServer;
@@ -82,12 +81,12 @@ public class YelpAPITest {
         final ArrayList<Business> returnedBusinessWrapper = new ArrayList<>();
         Callback<Business> businessCallback = new Callback<Business>() {
             @Override
-            public void onResponse(Response<Business> response, Retrofit retrofit) {
+            public void onResponse(Call<Business> call, Response<Business> response) {
                 returnedBusinessWrapper.add(response.body());
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Call<Business> call, Throwable t) {
                 Assert.fail("Unexpected failure: " + t.toString());
             }
         };
@@ -147,17 +146,10 @@ public class YelpAPITest {
         verifyResponseDeserializationForGetBusiness(business);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testGetBusinessWithNullParams() throws IOException, InterruptedException {
-        setUpMockServerResponse(200, "OK", businessJsonNode.toString());
-
-        String testBusinessId = "test-business-id";
-
-        Call<Business> call = yelpAPI.getBusiness(testBusinessId, null);
-        Business business = call.execute().body();
-
-        verifyRequestForGetBusiness(testBusinessId);
-        verifyResponseDeserializationForGetBusiness(business);
+        Call<Business> call = yelpAPI.getBusiness("test-business-id", null);
+        call.execute().body();
     }
 
     @Test
@@ -179,13 +171,14 @@ public class YelpAPITest {
 
         final ArrayList<SearchResponse> responseWrapper = new ArrayList<>();
         Callback<SearchResponse> businessCallback = new Callback<SearchResponse>() {
+
             @Override
-            public void onResponse(Response<SearchResponse> response, Retrofit retrofit) {
+            public void onResponse(Call<SearchResponse> call, Response<SearchResponse> response) {
                 responseWrapper.add(response.body());
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(Call<SearchResponse> call, Throwable t) {
                 Assert.fail("Unexpected failure: " + t.toString());
             }
         };
@@ -227,17 +220,10 @@ public class YelpAPITest {
         verifyResponseDeserializationForSearchResponse(searchResponse);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testGetPhoneSearchWithNullParams() throws IOException, InterruptedException {
-        setUpMockServerResponse(200, "OK", searchResponseJsonNode.toString());
-
-        String testPhone = "1234567899";
-
-        Call<SearchResponse> call = yelpAPI.getPhoneSearch(testPhone, null);
-        SearchResponse searchResponse = call.execute().body();
-
-        verifyRequestForGetPhoneSearch(testPhone);
-        verifyResponseDeserializationForSearchResponse(searchResponse);
+        Call<SearchResponse> call = yelpAPI.getPhoneSearch("1234567899", null);
+        call.execute().body();
     }
 
     @Test

--- a/src/test/java/com/yelp/clientlib/exception/ErrorHandlingInterceptorTest.java
+++ b/src/test/java/com/yelp/clientlib/exception/ErrorHandlingInterceptorTest.java
@@ -1,11 +1,11 @@
 package com.yelp.clientlib.exception;
 
-import com.squareup.okhttp.Interceptor;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.Protocol;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
-import com.squareup.okhttp.ResponseBody;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import com.yelp.clientlib.exception.exceptions.BusinessUnavailable;
 import com.yelp.clientlib.exception.exceptions.InternalError;
 import com.yelp.clientlib.exception.exceptions.InvalidParameter;

--- a/src/test/java/com/yelp/clientlib/utils/AsyncTestUtils.java
+++ b/src/test/java/com/yelp/clientlib/utils/AsyncTestUtils.java
@@ -1,7 +1,7 @@
 package com.yelp.clientlib.utils;
 
-import com.squareup.okhttp.Dispatcher;
-import com.squareup.okhttp.OkHttpClient;
+import okhttp3.Dispatcher;
+import okhttp3.OkHttpClient;
 import com.yelp.clientlib.connection.YelpAPIFactory;
 
 import org.junit.Assert;

--- a/src/test/java/com/yelp/clientlib/utils/AsyncTestUtils.java
+++ b/src/test/java/com/yelp/clientlib/utils/AsyncTestUtils.java
@@ -26,7 +26,8 @@ public class AsyncTestUtils {
 
         try {
             OkHttpClient httpClient = (OkHttpClient) PrivateAccessor.getField(yelpAPIFactory, "httpClient");
-            httpClient.setDispatcher(synchronousDispatcher);
+            OkHttpClient synchronousHttpClient = httpClient.newBuilder().dispatcher(synchronousDispatcher).build();
+            PrivateAccessor.setField(yelpAPIFactory, "httpClient", synchronousHttpClient);
         } catch (NoSuchFieldException e) {
             Assert.fail(e.toString());
         }


### PR DESCRIPTION
Upgrade the clientlib to use Retrofit 2.0.0 stable release. Okhttp and okhttp-signpost are also upgraded due to the compatibility to the Retrofit2.

Major differences are:
1. The signatures of the callback functions are changed for sending asynchronous requests. That also means this change is not backward compatible.
2. The QueryMaps are no longer be able to be passed into YelpAPI as null, IllegalArgumentException will be raised for it.