### PR TITLE
Bump clientlib version to 2.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
Bump version in build script to 2.0.0 as we are putting an non-backward compatible change for upgrading Retrofit from 2.0.0.beta to 2.0.0.