### PR TITLE
Bump package version to 2.0.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Download [the latest JAR](https://search.maven.org/remote_content?g=com.yelp.cli
 <dependency>
   <groupId>com.yelp.clientlib</groupId>
   <artifactId>yelp-android</artifactId>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     ...
-    compile 'com.yelp.clientlib:yelp-android:1.0.0'
+    compile 'com.yelp.clientlib:yelp-android:2.0.0'
     ...
 }
 ```


### PR DESCRIPTION
The 2.0.0 package is already in [Maven Central Repository](http://search.maven.org/#artifactdetails%7Ccom.yelp.clientlib%7Cyelp-android%7C2.0.0%7Cjar) and be ready to be pulled down by using maven and gradle. 

Bumping the version in README up to 2.0.0.